### PR TITLE
Fix mocha and mongo test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "mongo jsonresume-tests --eval \"db.dropDatabase(); db.resume.insert({});\" >/dev/null && echo Using blank DB",
-    "test": "mocha --reporter spec --require test/testHelper.js --colors"
+    "test": "mocha --reporter spec --require test/testHelper.js --colors --slow 800 --timeout 5000"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var supertest = require("supertest-as-promised")(Q.Promise);
 var HttpStatus = require('http-status-codes');
 var utils = require('./utils');
 
+process.env.MONGOHQ_URL = 'mongodb://localhost:27017/jsonresume-tests';
 process.env.POSTMARK_API_KEY = 'POSTMARK_API_TEST'; // http://blog.postmarkapp.com/post/913165552/handling-email-in-your-test-environment
 var server = require('../server');
 var api = supertest(server),


### PR DESCRIPTION
Increase Mocha timeout to prevent occasional test failures.

Make tests use the test DB (missed this in my last PR).