### PR TITLE
Fixes resume update as always overwriting, not merging

### DIFF
--- a/controller/upsertResume.js
+++ b/controller/upsertResume.js
@@ -41,7 +41,7 @@ module.exports = function upsertResume(req, res, next) {
                         'jsonresume.username': user.username
                     };
 
-                    Resume.update(conditions, resume, { upsert: true }, function(err, resume) {
+                    Resume.update(conditions, resume, { upsert: true, overwrite: true }, function(err, resume) {
                         if (err) {
                             return next(err);
                         }


### PR DESCRIPTION
 Because resume publish performs an update into MongoDB, it actually merges what is published with the latest persistent state. 
This can lead to difficulties in _removing_ properties, sections, etc. 

For example, publish a resume with a "volunteer" section, then publish it again without that section, and the "volunteer" section will still remain published -- as the version without it was just merged into the persistent one.  
