### PR TITLE
Update devDependencies: chai 3.3.0 --> 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "superagent": "^3.5"
   },
   "devDependencies": {
-    "chai": "^3.3.0",
+    "chai": "^4.1.2",
     "chai-properties": "^1.2.1",
     "mocha": "^3.3.0",
     "nock": "^9.0.13",


### PR DESCRIPTION
Updated chai version to fix docker build broken.
This fixes this issue: https://github.com/jsonresume/registry-server/issues/101